### PR TITLE
Add support for simulated time

### DIFF
--- a/txros/scripts/test
+++ b/txros/scripts/test
@@ -27,7 +27,7 @@ def main():
     @util.cancellableInlineCallbacks
     def task2():
         while True:
-            yield util.sleep(1)
+            yield nh.sleep(1)
             x = yield nh.get_param('/')
     task2()
 
@@ -35,7 +35,7 @@ def main():
     def task3():
         while nh.is_running():
             pub = nh.advertise('~point3', PointStamped, latching=True)
-            yield util.sleep(0.001)
+            yield nh.sleep(0.001)
             yield pub.shutdown()
     task3()
 

--- a/txros/scripts/test_tf
+++ b/txros/scripts/test_tf
@@ -29,5 +29,5 @@ def main():
             print transform
             print (transform2 - transform)/1e-3
             print
-        yield util.sleep(0.01)
+        yield nh.sleep(0.01)
 util.launch_main(main)

--- a/txros/src/txros/action.py
+++ b/txros/src/txros/action.py
@@ -144,4 +144,4 @@ class ActionClient(object):
                 set(self._status_sub.get_connections()) &
                 set(self._result_sub.get_connections()) &
                 set(self._feedback_sub.get_connections())):
-            yield util.sleep(0.1) # XXX bad bad bad
+            yield util.wall_sleep(0.1) # XXX bad bad bad

--- a/txros/src/txros/subscriber.py
+++ b/txros/src/txros/subscriber.py
@@ -105,7 +105,7 @@ class Subscriber(object):
             except Exception:
                 traceback.print_exc()
             
-            yield util.sleep(1)
+            yield util.wall_sleep(1) # pause so that we don't repeatedly reconnect immediately on failure
     
     def _handle_publisher_list(self, publishers):
         new = dict((k, self._publisher_threads.pop(k) if k in self._publisher_threads else self._publisher_thread(k)) for k in publishers)


### PR DESCRIPTION
This entailed deprecating txros.util.sleep in favor of the new NodeHandle.sleep and txros.util.wall_sleep methods.
