### PR TITLE
CI: Integrate txros with the Jenkins CI server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+dockerNode(image: 'uf-mil:txros') {
+	stage("Checkout") {
+		checkout scm
+		sh '''
+			ln -s `pwd` ~/catkin_ws/src/txros
+			git submodule update --init --recursive
+		'''
+	}
+	stage("Build") {
+		sh '''
+			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
+			catkin_make -C ~/catkin_ws -B
+		'''
+	}
+	stage("Test") {
+		sh '''
+			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
+			source ~/catkin_ws/devel/setup.bash > /dev/null 2>&1
+			trial txros
+		'''
+	}
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build Status](https://ci.mil.ufl.edu/jenkins/buildStatus/icon?job=txros/txros/master)](https://ci.mil.ufl.edu/jenkins/job/txros/job/txros/job/master/)
+
+# txROS
+
 txROS is an alternative Python client library for ROS (Robot Operating System).
 It seeks to improve on rospy by avoiding threading and providing other,
 potentially more useful interfaces, in addition to callbacks.
@@ -8,5 +12,3 @@ It is a work in progress, and as such, its API is not stable.
 This repository depends on Twisted, installable with:
 
     sudo apt-get install python-twisted
-
-[![Build Status](https://semaphoreci.com/api/v1/uf-mil/txros/branches/master/badge.svg)](https://semaphoreci.com/uf-mil/txros)

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,52 @@
+# This Docker file generates an image based on Ubuntu 16.04 and installs the
+# packages required for use with Jenkins CI. It also installs all of the
+# dependencies of txros.
+
+FROM ubuntu:xenial
+
+MAINTAINER Anthony Olive <anthony@iris-systems.net>
+
+# Update the image and install tools needed to create the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install sudo \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install lsb-release \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install git \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y autoremove --purge \
+	&& apt-get -y clean \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -f /var/cache/apt/*.bin
+
+# Install all dependencies of txros
+RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list \
+	&& echo "deb-src http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list.d/ros.list \
+	&& apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116 \
+	&& DEBIAN_FRONTEND=noninteractive apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install ros-kinetic-ros-base \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install ros-kinetic-roscpp-tutorials \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install ros-kinetic-tf \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install python-twisted \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y autoremove --purge \
+	&& apt-get -y clean \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -f /var/cache/apt/*.bin
+
+# Create a jenkins user for Jenkins CI and grant it passwordless sudo access
+RUN useradd --uid 10000 --create-home --shell /bin/bash jenkins \
+	&& echo "" >> /etc/sudoers \
+	&& echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Make Jenkins the default user for the image
+USER jenkins
+WORKDIR /home/jenkins
+SHELL ["/bin/bash", "-c"]
+
+# Create a volume to access the external files from Jenkins
+RUN mkdir /home/jenkins/.jenkins
+VOLUME /home/jenkins/.jenkins
+
+# Create a catkin workspace for the package
+RUN source /opt/ros/kinetic/setup.bash \
+	&& mkdir -p ~/catkin_ws/src \
+	&& cd ~/catkin_ws/src \
+	&& catkin_init_workspace


### PR DESCRIPTION
This adds txros to the Jenkins CI server for MIL. In order to fully integrate this repository, an organization hook will need to be created with the following settings:

* Payload URL - https://ci.mil.ufl.edu/jenkins/github-webhook/
* Content type - application/json
* Which events would you like to trigger this webhook? -  Send me everything.

This will trigger builds whenever a pull request or branch is updated.

In order for the commit status of a pull request to be updated, one of the maintainers will need to create a Personal access token with the `public_repo` and `repo:status` scopes. This should be sent to me directly, preferably by PGP encrypted email (my public key fingerprint is `04E843B6BC5CD8EC867D61695B062613F489F90F`). This is not necessary, but it would make checking the status of a pull request easier and enable requiring a passing build to merge.

Once this is merged, I would like to close out the uf-mil Semaphore account. Semaphore does not support the latest Ubuntu LTS, so it is incompatible with the uf-mil software stack.